### PR TITLE
Github Webhook handler implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 BOT_TOKEN="get from botfather"
 HOST=POLLING or WEBHOOK
+
+# Optional
+GITHUB_ORG=""

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": true
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "denoland.vscode-deno"
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ tool for Telegram groups.
 - `/unmute`: Restore a muted user's voice to the chat
 - `/warn`: Issue a yellow card to a user who's skating on thin ice
 - `/unwarn`: Erase a warning and wipe the slate clean
+- `/admin`: Add new admin
 
 Remember: Three strikes and they're out! (3 warnings = automatic ban)
 
@@ -66,6 +67,7 @@ Telegram and start a chat or add it to your group.
 - `/ban`, `/mute`, `/unban`, `/unmute`: Manage user restrictions
 - `/warn`, `/unwarn`: Manage user warnings Note: 3 warnings result in an
   automatic ban, resetting the warning count
+- `/admin`: Promote user to an admin
 
 ### Currency Exchange
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Remember: Three strikes and they're out! (3 warnings = automatic ban)
 ### Additional Features
 
 - Currency exchange functionality
+- Post Github Webhook Updates in a Group
 
 ## Technology Stack
 
@@ -100,6 +101,8 @@ cd kumiko
 ```
 
 4. Run the bot locally:
+
+`You will need to grant more than just a network, also use --unstable-kv flag too.`
 
 ```bash
 deno run --allow-net mod.ts

--- a/actions/mod.ts
+++ b/actions/mod.ts
@@ -2,6 +2,7 @@ export * from "./anime.ts";
 export * from "./start.ts";
 export * from "./source.ts";
 export * from "./help.ts";
+export * from "./setwebhook.ts";
 
 // Moderation commands
 

--- a/actions/moder/unwarn.ts
+++ b/actions/moder/unwarn.ts
@@ -24,7 +24,7 @@ async function handleUnwarn(ctx: Context): Promise<void> {
 bot
   .filter(async (ctx) => await isAdmin(ctx))
   .filter(async (ctx) => await isReplying(ctx))
-  .filter(async (ctx) => !isReplyingToMe(ctx))
+  .filter(async (ctx) => await !isReplyingToMe(ctx))
   .filter(async (ctx) => !await isReplyingToAdmin(ctx))
   .command("unwarn", async (ctx) => {
     try {

--- a/actions/moder/warn.ts
+++ b/actions/moder/warn.ts
@@ -36,7 +36,7 @@ async function handleWarning(ctx: Context): Promise<void> {
 bot
   .filter(async (ctx) => await isAdmin(ctx)) // Check if the user is an admin
   .filter(async (ctx) => await isReplying(ctx)) // Check if replying to a message
-  .filter(async (ctx) => !isReplyingToMe(ctx)) // Check if not replying to self
+  .filter(async (ctx) => await !isReplyingToMe(ctx)) // Check if not replying to self
   .filter(async (ctx) => !await isReplyingToAdmin(ctx)) // Check if not replying to admin
   .command("warn", async (ctx) => {
     try {

--- a/actions/setwebhook.ts
+++ b/actions/setwebhook.ts
@@ -1,0 +1,24 @@
+import { bot } from "../config/index.ts";
+import { Context } from "../deps.ts";
+import { isAdmin, isOwner } from "../utils/detect.ts";
+import { kv } from "../config/index.ts";
+
+bot.filter((ctx: Context) => ["group", "supergroup"].includes(ctx.chat?.type!))
+  .command("set", async (ctx: Context) => {
+    if (!Deno.env.get("GITHUB_ORG")) {
+      return await ctx.reply(
+        "You haven't set any GitHub organization in .env file.",
+      );
+    }
+
+    if (!await isAdmin(ctx) || !await isOwner(bot, ctx)) {
+      return await ctx.reply("Only admins can use this command!");
+    }
+
+    await kv.set(["thread_id"], {
+      chat_id: ctx.chat?.id,
+      thread_id: ctx.message?.message_thread_id,
+    });
+
+    await ctx.reply("The thread is set for GitHub webhooks!");
+  });

--- a/actions/webhook.ts
+++ b/actions/webhook.ts
@@ -1,0 +1,30 @@
+import { bot, kv } from "../config/index.ts";
+import { decideResponse } from "../utils/decidewebhook.ts";
+
+export async function handleGithubWebhook(req: Request): Promise<void> {
+  const body = await req.json();
+
+  // Ignore IN ANY CASE, it's update from another organization
+  if (
+    Deno.env.get("GITHUB_ORG")?.toLowerCase() !=
+      (body.organization.login as string).toLowerCase()
+  ) return;
+
+  const id_credentials = await kv.get<{ chat_id: number; thread_id: number }>([
+    "thread_id",
+  ]);
+
+  if (!id_credentials || !id_credentials.value) return;
+
+  const { chat_id, thread_id } = id_credentials.value;
+  const x_github_event = req.headers.get("X-GITHUB-EVENT") as string;
+  const response = await decideResponse(x_github_event, body);
+
+  if (response.text == "OK") return;
+
+  await bot.api.sendMessage(chat_id, response.text, {
+    message_thread_id: thread_id,
+    parse_mode: "HTML",
+    reply_markup: response.keyboard,
+  });
+}

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,1 +1,2 @@
 export { bot, instance } from "./bot.ts";
+export { kv } from "./kv.ts";

--- a/config/kv.ts
+++ b/config/kv.ts
@@ -1,0 +1,1 @@
+export const kv = await Deno.openKv();

--- a/db/warns.ts
+++ b/db/warns.ts
@@ -1,6 +1,5 @@
 import { Response } from "../types/response.ts";
-
-const kv = await Deno.openKv();
+import { kv } from "../config/index.ts";
 
 async function clearWarns(user_id: string | number): Promise<Response> {
   await kv.delete(["warns", user_id.toString()]);

--- a/serve.ts
+++ b/serve.ts
@@ -1,3 +1,4 @@
+import { handleGithubWebhook } from "./actions/webhook.ts";
 import { bot, instance } from "./config/index.ts";
 import { serve, webhookCallback } from "./deps.ts";
 import "https://deno.land/std@0.201.0/dotenv/load.ts";
@@ -18,6 +19,10 @@ const webhook = async () => {
             console.error(err);
             return new Response("Nope, not working...");
           }
+
+        case "/github-webhook":
+          await handleGithubWebhook(req);
+          return new Response("OK");
         default:
           return new Response("What you're trying to post?");
       }
@@ -34,7 +39,7 @@ const webhook = async () => {
       default:
         return Response.redirect(`https://t.me/${instance.username}`, 302);
     }
-  });
+  }, { port: 3000 });
 };
 
 const polling = async () => {

--- a/utils/decidewebhook.ts
+++ b/utils/decidewebhook.ts
@@ -1,0 +1,167 @@
+// deno-lint-ignore-file no-explicit-any
+import { InlineKeyboard } from "../deps.ts";
+
+/**
+ * ### Function to decide which event was triggered in the response.
+ * Supported events:
+ * - issue
+ * - star/unstar
+ * - commit
+ * - pull request
+ * - fork
+ * @param event
+ * @param body
+ * @returns  Text and keyboard to send to a specific `Promise<{ text: string; keyboard: InlineKeyboard }>`
+ */
+export function decideResponse(
+  event: string,
+  body: any,
+): { text: string; keyboard: InlineKeyboard } {
+  // Handle star/unstar
+  if (event == "star") {
+    switch (body.action) {
+      case "created":
+        return {
+          text:
+            `⭐️ New star on <a href="${body.repository.html_url}">${body.repository.full_name}</a> by <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b>`,
+          keyboard: new InlineKeyboard().url(
+            "Open in GitHub",
+            body.repository.html_url,
+          ),
+        };
+      case "deleted":
+        return {
+          text:
+            `❌⭐️ <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b> unstarred the <a href="${body.repository.html_url}">${body.repository.full_name}</a> repository.`,
+          keyboard: new InlineKeyboard().url(
+            "Open in GitHub",
+            body.repository.html_url,
+          ),
+        };
+    }
+  }
+
+  // Handle fork
+  if (event == "fork") {
+    return {
+      text:
+        `🍴 <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b> has forked the <a href="${body.repository.html_url}">${body.repository.full_name}</a> repository on <a href="${body.forkee.html_url}">${body.forkee.full_name}</a>`,
+      keyboard: new InlineKeyboard().url(
+        "Open in GitHub",
+        body.forkee.html_url,
+      ),
+    };
+  }
+
+  // Handle pull request
+  if (event == "pull_request") {
+    switch (body.action) {
+      case "opened":
+        return {
+          text:
+            `🧩 New pull request <b><a href="${body.pull_request.html_url}">#${body.pull_request.id}</a></b> created on <b><a href="${body.repository.html_url}">${body.repository.full_name}</a></b>\nTitle: ${body.pull_request.title}`,
+          keyboard: new InlineKeyboard().url(
+            "Open in GitHub",
+            body.pull_request.url,
+          ),
+        };
+      case "closed":
+        switch (body.pull_request.merged) {
+          case true:
+            return {
+              text:
+                `🧩 PR <b><a href="${body.pull_request.html_url}">#${body.pull_request.id}</a></b> on <b><a href="${body.repository.html_url}">${body.repository.full_name}</a></b> is merged.\nTitle: ${body.pull_request.title}`,
+              keyboard: new InlineKeyboard().url(
+                "Open in GitHub",
+                body.pull_request.url,
+              ),
+            };
+
+          case false:
+            return {
+              text:
+                `🧩 PR <b><a href="${body.pull_request.html_url}">#${body.pull_request.id}</a></b> on <b><a href="${body.repository.html_url}">${body.repository.full_name}</a></b> is closed.\nTitle: ${body.pull_request.title}`,
+              keyboard: new InlineKeyboard().url(
+                "Open in GitHub",
+                body.pull_request.url,
+              ),
+            };
+        }
+    }
+  }
+
+  // Handle issue
+  if (event == "issues") {
+    switch (body.action) {
+      case "opened":
+        return {
+          text:
+            `⭐️ New issue <b><a href="${body.issue.html_url}">#${body.issue.id}</a></b> was created on <a href="${body.repository.html_url}">${body.repository.full_name}</a> by <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b>\nTitle: ${body.issue.title}`,
+          keyboard: new InlineKeyboard().url(
+            "Open in GitHub",
+            body.issue.html_url,
+          ),
+        };
+
+      case "closed":
+        return {
+          text:
+            `⭐️ Issue <b><a href="${body.issue.html_url}">#${body.issue.id}</a></b> on <a href="${body.repository.html_url}">${body.repository.full_name}</a> is closed by <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b>\nTitle: ${body.issue.title}`,
+          keyboard: new InlineKeyboard().url(
+            "Open in GitHub",
+            body.issue.html_url,
+          ),
+        };
+
+      case "deleted":
+        return {
+          text:
+            `⭐️ Issue <b><a href="${body.issue.html_url}">#${body.issue.id}</a></b> on <a href="${body.repository.html_url}">${body.repository.full_name}</a> was deleted by <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b>\nTitle: ${body.issue.title}`,
+          keyboard: new InlineKeyboard().url(
+            "Open in GitHub",
+            body.issue.html_url,
+          ),
+        };
+    }
+  }
+
+  // Handle issue/pr comment
+  if (event == "issue_comment") {
+    switch (body.action) {
+      case "created":
+        return {
+          text:
+            `⭐️ New <b><a href="${body.comment.html_url}">comment</a></b> on <b><a href="${body.issue.html_url}">#${body.issue.id}</a></b> on <a href="${body.repository.html_url}">${body.repository.full_name}</a> by <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b>\nTitle: ${body.issue.title}`,
+          keyboard: new InlineKeyboard().url(
+            "Open in GitHub",
+            body.comment.html_url,
+          ),
+        };
+
+      case "deleted":
+        return {
+          text:
+            `⭐️ <b><a href="${body.comment.html_url}">Comment</a></b> on <b><a href="${body.issue.html_url}">#${body.issue.id}</a></b> on <a href="${body.repository.html_url}">${body.repository.full_name}</a> was deleted by <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b>\nTitle: ${body.issue.title}`,
+          keyboard: new InlineKeyboard().url(
+            "Open in GitHub",
+            body.comment.html_url,
+          ),
+        };
+    }
+  }
+
+  // Handle commit
+
+  if (event == "push") {
+    return {
+      text:
+        `🔨 New <b><a href="https://github.com/${body.repository.full_name}/commit/${body.after}">commit</a></b> on <a href="${body.repository.html_url}">${body.repository.full_name}</a> by <b><a href="${body.sender.html_url}">@${body.sender.login}</a></b>`,
+      keyboard: new InlineKeyboard().url(
+        "Open in GitHub",
+        `https://github.com/${body.repository.full_name}/commit/${body.after}`,
+      ),
+    };
+  }
+
+  return { text: "OK", keyboard: new InlineKeyboard() };
+}


### PR DESCRIPTION
### Description
This PR adds the ability to handle GitHub webhooks with these improvements:


### Changes
- New endpoint to receive GitHub webhook notifications (d3ab606)
- Code to identify what type of GitHub event happened (2096086)
- Special command to set which thread handles GitHub updates (e9a247a)
- Fixed config by moving settings to the right place (016d720)
- Added clear explanation of how this feature works (f657dd6)

All changes build on the initial webhook update handling (264b58c).

These changes let our bot automatically respond when something happens on GitHub. 
